### PR TITLE
Configurando Authorization Server para o projeto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/keys/*.pem

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,17 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk15on</artifactId>
+			<version>1.70</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk15on</artifactId>
+			<version>1.70</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/project/crud/config/ClientStoreConfig.java
+++ b/src/main/java/project/crud/config/ClientStoreConfig.java
@@ -1,0 +1,38 @@
+package project.crud.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+
+import java.util.UUID;
+
+@Configuration
+public class ClientStoreConfig {
+    @Bean
+    InMemoryRegisteredClientRepository registeredClient() {
+        RegisteredClient registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId("client_server")
+                .clientSecret("{noop}secret") // Em produção usar bycrypt
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                .redirectUri("http://localhost:8080/login/oauth2/code/custom")
+                .redirectUri("http://localhost:8080/oauth2/callback")
+                .redirectUri("http://localhost:8080/authorized")
+                .scope(OidcScopes.OPENID)
+                .scope(OidcScopes.PROFILE)
+                .scope("read")
+                .scope("write")
+                .clientSettings(ClientSettings.builder()
+                        .requireAuthorizationConsent(true)
+                        .build())
+                .build();
+
+        return new InMemoryRegisteredClientRepository(registeredClient);
+    }
+}

--- a/src/main/java/project/crud/config/UserStoreConfig.java
+++ b/src/main/java/project/crud/config/UserStoreConfig.java
@@ -1,0 +1,23 @@
+package project.crud.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+public class UserStoreConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        var userDetailsManagaer = new InMemoryUserDetailsManager();
+        userDetailsManagaer.createUser(
+                User.withUsername("user")
+                        .password("{noop}password")
+                        .roles("USER")
+                        .build());
+
+        return userDetailsManagaer;
+    }
+}

--- a/src/main/java/project/crud/security/authorization/AuthorizationServerConfig.java
+++ b/src/main/java/project/crud/security/authorization/AuthorizationServerConfig.java
@@ -1,0 +1,24 @@
+package project.crud.security.authorization;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class AuthorizationServerConfig {
+
+    @Bean
+    public SecurityFilterChain authServerSecurityFilterChain(HttpSecurity http) throws Exception {
+        OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
+        return http.build();
+    }
+
+
+    @Bean
+    AuthorizationServerSettings authorizationServerSettings() {
+        return AuthorizationServerSettings.builder().build();
+    }
+}

--- a/src/main/java/project/crud/security/authorization/JwkConfig.java
+++ b/src/main/java/project/crud/security/authorization/JwkConfig.java
@@ -1,0 +1,53 @@
+package project.crud.security.authorization;
+
+import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.jwk.source.*;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.bouncycastle.util.io.pem.PemReader;
+
+import java.io.FileReader;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwkConfig {
+
+    @Bean
+    public JWKSource<SecurityContext> jwkSource() throws Exception {
+        RSAPublicKey publicKey = loadPublicKey("src/main/resources/keys/public_key.pem");
+        RSAPrivateKey privateKey = loadPrivateKey("src/main/resources/keys/private_key.pem");
+
+        RSAKey rsaKey = new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(UUID.randomUUID().toString())
+                .build();
+
+        JWKSet jwkSet = new JWKSet(rsaKey);
+        return new ImmutableJWKSet<>(jwkSet);
+    }
+
+    private RSAPrivateKey loadPrivateKey(String filepath) throws Exception {
+        try (PemReader pemReader = new PemReader(new FileReader(filepath))) {
+            byte[] content = pemReader.readPemObject().getContent();
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(content);
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            return (RSAPrivateKey) kf.generatePrivate(spec);
+        }
+    }
+
+    private RSAPublicKey loadPublicKey(String filepath) throws Exception {
+        try (PemReader pemReader = new PemReader(new FileReader(filepath))) {
+            byte[] content = pemReader.readPemObject().getContent();
+            X509EncodedKeySpec spec = new X509EncodedKeySpec(content);
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            return (RSAPublicKey) kf.generatePublic(spec);
+        }
+    }
+}

--- a/src/main/java/project/crud/security/authorization/JwtEnconder.java
+++ b/src/main/java/project/crud/security/authorization/JwtEnconder.java
@@ -1,0 +1,15 @@
+package project.crud.security.authorization;
+
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+
+public class JwtEnconder {
+
+    @Bean
+    JwtDecoder jwtEnconder(JWKSource<SecurityContext> jwkSource) {
+        return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
+    }
+}

--- a/src/main/java/project/crud/security/authorization/SecurityFilterConfig.java
+++ b/src/main/java/project/crud/security/authorization/SecurityFilterConfig.java
@@ -1,0 +1,46 @@
+package project.crud.security.authorization;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+public class SecurityFilterConfig {
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain authorizationServerFilterChain(HttpSecurity http) throws Exception {
+        OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
+
+        http.getConfigurer(OAuth2AuthorizationServerConfigurer.class).oidc(withDefaults());
+
+        http.exceptionHandling(exception -> exception
+                .authenticationEntryPoint(
+                        new LoginUrlAuthenticationEntryPoint("/login")
+                )).oauth2ResourceServer(conf -> conf.jwt(withDefaults()));
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/oauth2/**", "/login", "/error").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(Customizer.withDefaults())
+                .oauth2Login(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=CRUD-Project
 
+server.port=8080
+
 spring.datasource.url=jdbc:postgresql://localhost:5432/database_user
 spring.datasource.username=postgres
 spring.datasource.password=postgres
@@ -9,3 +11,16 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+logging.level.org.springframework.security=trace
+
+spring.security.oauth2.client.registration.custom.client-id=client_server
+spring.security.oauth2.client.registration.custom.client-secret=secret
+spring.security.oauth2.client.registration.custom.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.custom.redirect-uri=http://localhost:8080/login/oauth2/code/custom
+spring.security.oauth2.client.registration.custom.scope=openid,profile
+
+spring.security.oauth2.client.provider.custom.authorization-uri=http://localhost:8080/oauth2/authorize
+spring.security.oauth2.client.provider.custom.token-uri=http://localhost:8080/oauth2/token
+spring.security.oauth2.client.provider.custom.user-info-uri=http://localhost:8080/userinfo
+spring.security.oauth2.client.provider.custom.jwk-set-uri=http://localhost:8080/oauth2/jwks


### PR DESCRIPTION
Foi configurado a parte de Authorization Server para o projeto, que é uma dependência que gera um token para, futuramente, proteger as APIs do projeto utilizando o Resource Server que será adicionado depois.

Atualização do .gitignore para ignorar adição das chaves, públicas e privadas. Chaves essas que são RSA e do tipo PKCS8.

Foi criado um cliente em memória para utilizar a dependência.

Closes #21 